### PR TITLE
[TIME] 시간 및 통계 관련 기능 구현

### DIFF
--- a/src/main/java/com/buddy/study/StudyApplication.java
+++ b/src/main/java/com/buddy/study/StudyApplication.java
@@ -1,10 +1,16 @@
 package com.buddy.study;
 
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class StudyApplication {
+	@PostConstruct
+	void started() {
+	  TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 
 	public static void main(String[] args) {
 		SpringApplication.run(StudyApplication.class, args);

--- a/src/main/java/com/buddy/study/common/dto/ErrorCode.java
+++ b/src/main/java/com/buddy/study/common/dto/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL("C001","이메일이 중복되었습니다."),
     MAXIMUM_GROUP("C002","현재 최대인원으로 가입할 수 없습니다."),
     DUPLICATE_GROUP("C003", "이미 가입한 그룹입니다."),
+    INVALIDATE_DATE("C004", "날짜 형식이 요구되는 형식과 맞지 않습니다."),
 
     //Unauthorized : 401
     INVALID_EMAIL("U000","가입되지 않은 이메일입니다."),

--- a/src/main/java/com/buddy/study/time/controller/TimeController.java
+++ b/src/main/java/com/buddy/study/time/controller/TimeController.java
@@ -6,12 +6,14 @@ import com.buddy.study.time.dto.TimeReportResponse;
 import com.buddy.study.time.dto.TimeResponse;
 import com.buddy.study.time.service.TimeService;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,18 +24,18 @@ public class TimeController {
     private final TimeService timeService;
 
     @PostMapping("")
-    public ResponseEntity<TimeResponse> createTime(@RequestBody CreateRequest request) {
-        return ResponseEntity.ok(timeService.createTime(request));
+    public ResponseEntity<TimeResponse> createTime(@RequestHeader("Authorization") UUID userId, @RequestBody CreateRequest request) {
+        return ResponseEntity.ok(timeService.createTime(userId, request));
     }
 
     @GetMapping("/month/{month}")
-    public ResponseEntity<List<TimeResponse>> getTimesByMonth(@PathVariable String month) {
-        return ResponseEntity.ok(timeService.getTimesByMonth(month));
+    public ResponseEntity<List<TimeResponse>> getTimesByMonth(@RequestHeader("Authorization") UUID userId, @PathVariable String month) {
+        return ResponseEntity.ok(timeService.getTimesByMonth(userId, month));
     }
 
     @GetMapping("/month/{month}/report")
-    public ResponseEntity<TimeReportResponse> getReportByMonth(@PathVariable String month) {
-        return ResponseEntity.ok(timeService.getTimeReportByMonth(month));
+    public ResponseEntity<TimeReportResponse> getReportByMonth(@RequestHeader("Authorization") UUID userId, @PathVariable String month) {
+        return ResponseEntity.ok(timeService.getTimeReportByMonth(userId, month));
     }
 
 }

--- a/src/main/java/com/buddy/study/time/controller/TimeController.java
+++ b/src/main/java/com/buddy/study/time/controller/TimeController.java
@@ -1,0 +1,39 @@
+package com.buddy.study.time.controller;
+
+import com.buddy.study.time.domain.Time;
+import com.buddy.study.time.dto.CreateRequest;
+import com.buddy.study.time.dto.TimeReportResponse;
+import com.buddy.study.time.dto.TimeResponse;
+import com.buddy.study.time.service.TimeService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/time")
+public class TimeController {
+    private final TimeService timeService;
+
+    @PostMapping("")
+    public ResponseEntity<TimeResponse> createTime(@RequestBody CreateRequest request) {
+        return ResponseEntity.ok(timeService.createTime(request));
+    }
+
+    @GetMapping("/month/{month}")
+    public ResponseEntity<List<TimeResponse>> getTimesByMonth(@PathVariable String month) {
+        return ResponseEntity.ok(timeService.getTimesByMonth(month));
+    }
+
+    @GetMapping("/month/{month}/report")
+    public ResponseEntity<TimeReportResponse> getReportByMonth(@PathVariable String month) {
+        return ResponseEntity.ok(timeService.getTimeReportByMonth(month));
+    }
+
+}

--- a/src/main/java/com/buddy/study/time/controller/TimeController.java
+++ b/src/main/java/com/buddy/study/time/controller/TimeController.java
@@ -1,6 +1,5 @@
 package com.buddy.study.time.controller;
 
-import com.buddy.study.time.domain.Time;
 import com.buddy.study.time.dto.CreateRequest;
 import com.buddy.study.time.dto.TimeReportResponse;
 import com.buddy.study.time.dto.TimeResponse;
@@ -30,12 +29,21 @@ public class TimeController {
 
     @GetMapping("/month/{month}")
     public ResponseEntity<List<TimeResponse>> getTimesByMonth(@RequestHeader("Authorization") UUID userId, @PathVariable String month) {
-        return ResponseEntity.ok(timeService.getTimesByMonth(userId, month));
+        String formattedMonth =  timeService.validateDate(month);
+        System.out.println(formattedMonth);
+        return ResponseEntity.ok(timeService.getTimesByMonth(userId, formattedMonth));
     }
 
     @GetMapping("/month/{month}/report")
     public ResponseEntity<TimeReportResponse> getReportByMonth(@RequestHeader("Authorization") UUID userId, @PathVariable String month) {
-        return ResponseEntity.ok(timeService.getTimeReportByMonth(userId, month));
+        String formattedMonth =  timeService.validateDate(month);
+        System.out.println(formattedMonth);
+        return ResponseEntity.ok(timeService.getTimeReportByMonth(userId, formattedMonth));
+    }
+
+    @GetMapping("/today")
+    public ResponseEntity<TimeResponse> getTodayTime(@RequestHeader("Authorization") UUID userId) {
+        return ResponseEntity.ok(timeService.getTodayTime(userId));
     }
 
 }

--- a/src/main/java/com/buddy/study/time/domain/Time.java
+++ b/src/main/java/com/buddy/study/time/domain/Time.java
@@ -1,0 +1,14 @@
+package com.buddy.study.time.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Time {
+    @Id
+    @GeneratedValue
+    @Column(name="timeId")
+    private Long id;
+}

--- a/src/main/java/com/buddy/study/time/domain/Time.java
+++ b/src/main/java/com/buddy/study/time/domain/Time.java
@@ -10,9 +10,11 @@ import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 public class Time {
     @Id
@@ -28,7 +30,6 @@ public class Time {
 
     @ManyToOne
     @JoinColumn(name="userId")
-    @Column
     private Account account;
 
     @Builder

--- a/src/main/java/com/buddy/study/time/domain/Time.java
+++ b/src/main/java/com/buddy/study/time/domain/Time.java
@@ -1,14 +1,40 @@
 package com.buddy.study.time.domain;
 
+import com.buddy.study.account.domain.Account;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class Time {
     @Id
     @GeneratedValue
     @Column(name="timeId")
     private Long id;
+
+    @Column
+    private String date;
+
+    @Column
+    private Float time;
+
+    @ManyToOne
+    @JoinColumn(name="userId")
+    @Column
+    private Account account;
+
+    @Builder
+    public Time(String date, Float time, Account account) {
+        this.date = date;
+        this.time = time;
+        this.account = account;
+    }
 }

--- a/src/main/java/com/buddy/study/time/dto/CreateRequest.java
+++ b/src/main/java/com/buddy/study/time/dto/CreateRequest.java
@@ -1,0 +1,5 @@
+package com.buddy.study.time.dto;
+
+public class CreateRequest {
+
+}

--- a/src/main/java/com/buddy/study/time/dto/CreateRequest.java
+++ b/src/main/java/com/buddy/study/time/dto/CreateRequest.java
@@ -1,5 +1,10 @@
 package com.buddy.study.time.dto;
 
-public class CreateRequest {
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@NoArgsConstructor
+public class CreateRequest {
+    private Float time;
 }

--- a/src/main/java/com/buddy/study/time/dto/TimeReportResponse.java
+++ b/src/main/java/com/buddy/study/time/dto/TimeReportResponse.java
@@ -1,12 +1,21 @@
 package com.buddy.study.time.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class TimeReportResponse {
-    private String month;
     private Float average;
     private Float cumulative;
     private Float maximum;
     private Float minimum;
+    private String month;
+
+    public TimeReportResponse(Double average, Double cumulative, Float maximum, Float minimum) {
+        this.average = average.floatValue();
+        this.cumulative = cumulative.floatValue();
+        this.maximum = maximum;
+        this.minimum = minimum;
+    }
 }

--- a/src/main/java/com/buddy/study/time/dto/TimeReportResponse.java
+++ b/src/main/java/com/buddy/study/time/dto/TimeReportResponse.java
@@ -1,0 +1,5 @@
+package com.buddy.study.time.dto;
+
+public class TimeReportResponse {
+
+}

--- a/src/main/java/com/buddy/study/time/dto/TimeReportResponse.java
+++ b/src/main/java/com/buddy/study/time/dto/TimeReportResponse.java
@@ -1,5 +1,12 @@
 package com.buddy.study.time.dto;
 
-public class TimeReportResponse {
+import lombok.Getter;
 
+@Getter
+public class TimeReportResponse {
+    private String month;
+    private Float average;
+    private Float cumulative;
+    private Float maximum;
+    private Float minimum;
 }

--- a/src/main/java/com/buddy/study/time/dto/TimeResponse.java
+++ b/src/main/java/com/buddy/study/time/dto/TimeResponse.java
@@ -1,5 +1,17 @@
 package com.buddy.study.time.dto;
 
-public class TimeResponse {
+import com.buddy.study.time.domain.Time;
+import lombok.Getter;
 
+@Getter
+public class TimeResponse {
+    private Long id;
+    private String date;
+    private Float time;
+
+    public TimeResponse(Time time) {
+        this.id = time.getId();
+        this.date = time.getDate();
+        this.time = time.getTime();
+    }
 }

--- a/src/main/java/com/buddy/study/time/dto/TimeResponse.java
+++ b/src/main/java/com/buddy/study/time/dto/TimeResponse.java
@@ -1,0 +1,5 @@
+package com.buddy.study.time.dto;
+
+public class TimeResponse {
+
+}

--- a/src/main/java/com/buddy/study/time/repository/TimeRepository.java
+++ b/src/main/java/com/buddy/study/time/repository/TimeRepository.java
@@ -3,15 +3,18 @@ package com.buddy.study.time.repository;
 import com.buddy.study.account.domain.Account;
 import com.buddy.study.time.domain.Time;
 import com.buddy.study.time.dto.TimeReportResponse;
-import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TimeRepository extends JpaRepository<Time, Long> {
-    @Query("select t from Time t where t.account = :account and t.date like :date%")
+    @Query("select t from Time t where t.account = :account and t.date like :date% order by t.date")
     List<Time> findAllByDateAndAccount(String date, Account account); // date YYYY-MM
 
-    @Query("select t.date, AVG(t.time), SUM(t.time), MAX(t.time), MIN(t.time) from Time t where t.account = :account and t.date like :date%")
+    @Query("select new com.buddy.study.time.dto.TimeReportResponse(AVG(t.time), SUM(t.time), MAX(t.time), MIN(t.time)) from Time t where t.account = :account and t.date like :date%")
     TimeReportResponse findReportByDateAndAccount(String date, Account account);
+
+    @Query("select t from Time t where t.account = :account and t.date like :date%")
+    Optional<Time> findOneByDateAndAccount(String date, Account account);
 }

--- a/src/main/java/com/buddy/study/time/repository/TimeRepository.java
+++ b/src/main/java/com/buddy/study/time/repository/TimeRepository.java
@@ -1,8 +1,17 @@
 package com.buddy.study.time.repository;
 
+import com.buddy.study.account.domain.Account;
 import com.buddy.study.time.domain.Time;
+import com.buddy.study.time.dto.TimeReportResponse;
+import java.util.Date;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TimeRepository extends JpaRepository<Time, Long> {
+    @Query("select t from Time t where t.account = :account and t.date like :date%")
+    List<Time> findAllByDateAndAccount(String date, Account account); // date YYYY-MM
 
+    @Query("select t.date, AVG(t.time), SUM(t.time), MAX(t.time), MIN(t.time) from Time t where t.account = :account and t.date like :date%")
+    TimeReportResponse findReportByDateAndAccount(String date, Account account);
 }

--- a/src/main/java/com/buddy/study/time/repository/TimeRepository.java
+++ b/src/main/java/com/buddy/study/time/repository/TimeRepository.java
@@ -1,0 +1,8 @@
+package com.buddy.study.time.repository;
+
+import com.buddy.study.time.domain.Time;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TimeRepository extends JpaRepository<Time, Long> {
+
+}

--- a/src/main/java/com/buddy/study/time/service/TimeService.java
+++ b/src/main/java/com/buddy/study/time/service/TimeService.java
@@ -41,7 +41,7 @@ public class TimeService {
     }
     public TimeResponse createTime(UUID userId, CreateRequest request) {
         Account account = accountService.findUser(userId);
-        String today = "2022-10-19";
+        String today = LocalDate.now().toString();
 
         Optional<Time> exist = timeRepository.findOneByDateAndAccount(today, account);
         Time time = exist.orElseGet(() -> Time.builder()

--- a/src/main/java/com/buddy/study/time/service/TimeService.java
+++ b/src/main/java/com/buddy/study/time/service/TimeService.java
@@ -1,0 +1,28 @@
+package com.buddy.study.time.service;
+
+import com.buddy.study.time.dto.CreateRequest;
+import com.buddy.study.time.dto.TimeReportResponse;
+import com.buddy.study.time.dto.TimeResponse;
+import com.buddy.study.time.repository.TimeRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TimeService {
+    private final TimeRepository timeRepository;
+
+    public TimeResponse createTime(CreateRequest request) {
+        return null;
+    }
+
+    public List<TimeResponse> getTimesByMonth(String month) {
+        return null;
+    }
+
+    public TimeReportResponse getTimeReportByMonth(String month) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/buddy/study/time/service/TimeService.java
+++ b/src/main/java/com/buddy/study/time/service/TimeService.java
@@ -2,13 +2,19 @@ package com.buddy.study.time.service;
 
 import com.buddy.study.account.domain.Account;
 import com.buddy.study.account.service.AccountService;
+import com.buddy.study.common.dto.ErrorCode;
+import com.buddy.study.common.exception.ConflictException;
 import com.buddy.study.time.domain.Time;
 import com.buddy.study.time.dto.CreateRequest;
 import com.buddy.study.time.dto.TimeReportResponse;
 import com.buddy.study.time.dto.TimeResponse;
 import com.buddy.study.time.repository.TimeRepository;
-import java.time.LocalDateTime;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.transaction.Transactional;
@@ -23,14 +29,27 @@ public class TimeService {
 
     private final AccountService accountService;
 
+    public String validateDate(String date) { // yyyy-MM 형식인지 검증
+        try {
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM");
+            simpleDateFormat.setLenient(false);
+            Date result = simpleDateFormat.parse(date);
+            return simpleDateFormat.format(result);
+        } catch(ParseException e) {
+            throw new ConflictException(ErrorCode.INVALIDATE_DATE);
+        }
+    }
     public TimeResponse createTime(UUID userId, CreateRequest request) {
         Account account = accountService.findUser(userId);
-        String date = LocalDateTime.now().toString();
-        Time time = Time.builder()
-            .date(date)
-            .time(request.getTime())
+        String today = "2022-10-19";
+
+        Optional<Time> exist = timeRepository.findOneByDateAndAccount(today, account);
+        Time time = exist.orElseGet(() -> Time.builder()
+            .date(today)
+            .time(0F)
             .account(account)
-            .build();
+            .build());
+        time.setTime(time.getTime()+request.getTime());
         return new TimeResponse(timeRepository.save(time));
     }
 
@@ -46,7 +65,17 @@ public class TimeService {
     public TimeReportResponse getTimeReportByMonth(UUID userId, String month) {
         Account account = accountService.findUser(userId);
 
-        return timeRepository.findReportByDateAndAccount(month, account);
+        TimeReportResponse response = timeRepository.findReportByDateAndAccount(month, account);
+        response.setMonth(month);
+        return response;
     }
 
+    public TimeResponse getTodayTime(UUID userId) {
+        Account account = accountService.findUser(userId);
+
+        String today = LocalDate.now().toString();
+        Time time = timeRepository.findOneByDateAndAccount(today, account)
+            .orElse(new Time(today,0F, account));
+        return new TimeResponse(time);
+    }
 }

--- a/src/main/java/com/buddy/study/time/service/TimeService.java
+++ b/src/main/java/com/buddy/study/time/service/TimeService.java
@@ -1,28 +1,52 @@
 package com.buddy.study.time.service;
 
+import com.buddy.study.account.domain.Account;
+import com.buddy.study.account.service.AccountService;
+import com.buddy.study.time.domain.Time;
 import com.buddy.study.time.dto.CreateRequest;
 import com.buddy.study.time.dto.TimeReportResponse;
 import com.buddy.study.time.dto.TimeResponse;
 import com.buddy.study.time.repository.TimeRepository;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class TimeService {
     private final TimeRepository timeRepository;
 
-    public TimeResponse createTime(CreateRequest request) {
-        return null;
+    private final AccountService accountService;
+
+    public TimeResponse createTime(UUID userId, CreateRequest request) {
+        Account account = accountService.findUser(userId);
+        String date = LocalDateTime.now().toString();
+        Time time = Time.builder()
+            .date(date)
+            .time(request.getTime())
+            .account(account)
+            .build();
+        return new TimeResponse(timeRepository.save(time));
     }
 
-    public List<TimeResponse> getTimesByMonth(String month) {
-        return null;
+    public List<TimeResponse> getTimesByMonth(UUID userId, String month) {
+        Account account = accountService.findUser(userId);
+
+        return timeRepository.findAllByDateAndAccount(month,account)
+            .stream()
+            .map(TimeResponse::new)
+            .collect(Collectors.toList());
     }
 
-    public TimeReportResponse getTimeReportByMonth(String month) {
-        return null;
+    public TimeReportResponse getTimeReportByMonth(UUID userId, String month) {
+        Account account = accountService.findUser(userId);
+
+        return timeRepository.findReportByDateAndAccount(month, account);
     }
 
 }


### PR DESCRIPTION
마찬가지로 헤더에 사용자 인증 정보 (사용자 id, UUID) 포함해서 요청해야합니다!
![스크린샷 2022-11-26 오전 12 31 46](https://user-images.githubusercontent.com/69030160/204016669-aef1bb1f-95db-46c1-8afc-08c2f559d484.png)
- 공부 시간 생성 `POST /api/v1/time`
![시간 생성](https://user-images.githubusercontent.com/69030160/204017431-57e88c3e-7e39-4d17-ac11-074bd889d2d4.png)


- 오늘 공부 시간 조회 `GET /api/v1/time/today`
![오늘 시간 정보 조회](https://user-images.githubusercontent.com/69030160/204017457-ec1e4dbf-dd0f-43d6-ab14-a04a91ca84e7.png)

🚧  월별로 조회하는 API의 경우 (월별 공부 시간 조회, 월별 공부 시간 통계 조회), 
요청 url에서의 `{month}`가 `yyyy-mm` 혹은 `yyyy-mm-dd` (이때 `dd`는 무시됨)가 아닐 경우 아래와 같은 예외가 발생합니다. 🚧
![시간 예외 처리](https://user-images.githubusercontent.com/69030160/204017803-2c50b0aa-0d67-4a86-ae95-8f1f8f172844.png)

- 월별 공부 시간 조회 `GET /api/v1/time/month/{month}` ex) `GET /api/v1/time/month/2022-11-23`
![월별 시간 조회](https://user-images.githubusercontent.com/69030160/204017467-6e4fce55-f68f-43bf-bbda-658da34baf64.png)

- 월별 공부 시간 통계 조회 `GET /api/v1/time/month/{month}/report` ex) `GET /api/v1/time/month/2022-10/report`
![스크린샷 2022-11-26 오전 12 14 11](https://user-images.githubusercontent.com/69030160/204017864-118f86ba-e005-4d36-a32d-c02dc05b8752.png)
