### PR TITLE
[POSTURE] 자세 관련 기능 구현

### DIFF
--- a/src/main/java/com/buddy/study/posture/controller/PostureController.java
+++ b/src/main/java/com/buddy/study/posture/controller/PostureController.java
@@ -1,0 +1,33 @@
+package com.buddy.study.posture.controller;
+
+import com.buddy.study.posture.dto.CreateRequest;
+import com.buddy.study.posture.dto.PostureResponse;
+import com.buddy.study.posture.service.PostureService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posture")
+public class PostureController {
+    private final PostureService postureService;
+    @Operation(summary = "온도 업데이트")
+    @PostMapping
+    public ResponseEntity<PostureResponse> createTemperature(@RequestHeader("Authorization") UUID userId, @RequestBody CreateRequest request) {
+        return ResponseEntity.ok(postureService.createPosture(userId, request));
+    }
+    @Operation(summary = "온도 조회")
+    @GetMapping
+    public ResponseEntity<PostureResponse> getTemperature(@RequestHeader("Authorization") UUID userId) {
+        return ResponseEntity.ok(postureService.getPosture(userId));
+    }
+
+}

--- a/src/main/java/com/buddy/study/posture/controller/PostureController.java
+++ b/src/main/java/com/buddy/study/posture/controller/PostureController.java
@@ -19,12 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/posture")
 public class PostureController {
     private final PostureService postureService;
-    @Operation(summary = "온도 업데이트")
+    @Operation(summary = "자세 업데이트")
     @PostMapping
     public ResponseEntity<PostureResponse> createTemperature(@RequestHeader("Authorization") UUID userId, @RequestBody CreateRequest request) {
         return ResponseEntity.ok(postureService.createPosture(userId, request));
     }
-    @Operation(summary = "온도 조회")
+    @Operation(summary = "자세 조회")
     @GetMapping
     public ResponseEntity<PostureResponse> getTemperature(@RequestHeader("Authorization") UUID userId) {
         return ResponseEntity.ok(postureService.getPosture(userId));

--- a/src/main/java/com/buddy/study/posture/domain/Posture.java
+++ b/src/main/java/com/buddy/study/posture/domain/Posture.java
@@ -1,0 +1,33 @@
+package com.buddy.study.posture.domain;
+
+import com.buddy.study.account.domain.Account;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Posture {
+    @Id
+    @GeneratedValue
+    @Column(name="postureId")
+    private Long id;
+
+    @Column
+    private Boolean isAppropriate;
+
+    @ManyToOne
+    @JoinColumn(name = "userId")
+    private Account account;
+
+    public Posture(Boolean isAppropriate, Account account) {
+        this.isAppropriate = isAppropriate;
+        this.account = account;
+    }
+}

--- a/src/main/java/com/buddy/study/posture/dto/CreateRequest.java
+++ b/src/main/java/com/buddy/study/posture/dto/CreateRequest.java
@@ -1,0 +1,10 @@
+package com.buddy.study.posture.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateRequest {
+    private Boolean isAppropriate;
+}

--- a/src/main/java/com/buddy/study/posture/dto/PostureResponse.java
+++ b/src/main/java/com/buddy/study/posture/dto/PostureResponse.java
@@ -1,0 +1,15 @@
+package com.buddy.study.posture.dto;
+
+import com.buddy.study.posture.domain.Posture;
+import lombok.Getter;
+
+@Getter
+public class PostureResponse {
+    private Long id;
+    private Boolean isAppropriate;
+
+    public PostureResponse(Posture posture) {
+        this.id = posture.getId();
+        this.isAppropriate = posture.getIsAppropriate();
+    }
+}

--- a/src/main/java/com/buddy/study/posture/repository/PostureRepository.java
+++ b/src/main/java/com/buddy/study/posture/repository/PostureRepository.java
@@ -1,0 +1,11 @@
+package com.buddy.study.posture.repository;
+
+import com.buddy.study.account.domain.Account;
+import com.buddy.study.posture.domain.Posture;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostureRepository extends JpaRepository<Posture, Long> {
+
+    Optional<Posture> findTopByAccountOrderByIdDesc(Account account);
+}

--- a/src/main/java/com/buddy/study/posture/service/PostureService.java
+++ b/src/main/java/com/buddy/study/posture/service/PostureService.java
@@ -28,7 +28,7 @@ public class PostureService {
         Account account = accountService.findUser(userId);
 
         Posture posture = postureRepository.findTopByAccountOrderByIdDesc(account)
-            .orElse(postureRepository.save(new Posture(true, account)));
+            .orElseGet(()-> postureRepository.save(new Posture(true, account)));
         return new PostureResponse(posture);
     }
 }

--- a/src/main/java/com/buddy/study/posture/service/PostureService.java
+++ b/src/main/java/com/buddy/study/posture/service/PostureService.java
@@ -1,0 +1,34 @@
+package com.buddy.study.posture.service;
+
+import com.buddy.study.account.domain.Account;
+import com.buddy.study.account.service.AccountService;
+import com.buddy.study.posture.domain.Posture;
+import com.buddy.study.posture.dto.CreateRequest;
+import com.buddy.study.posture.dto.PostureResponse;
+import com.buddy.study.posture.repository.PostureRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostureService {
+    private final PostureRepository postureRepository;
+
+    private final AccountService accountService;
+
+    public PostureResponse createPosture(UUID userId, CreateRequest request) {
+        Account account = accountService.findUser(userId);
+
+        Posture posture = new Posture(request.getIsAppropriate(), account);
+        return new PostureResponse(postureRepository.save(posture));
+    }
+
+    public PostureResponse getPosture(UUID userId) {
+        Account account = accountService.findUser(userId);
+
+        Posture posture = postureRepository.findTopByAccountOrderByIdDesc(account)
+            .orElse(postureRepository.save(new Posture(true, account)));
+        return new PostureResponse(posture);
+    }
+}


### PR DESCRIPTION
마찬가지로 요청시 사용자 인증 정보 헤더 필요합니다!
- 자세 생성 (자세 업데이트) `POST /api/v1/posture`
  <img width="1025" alt="스크린샷 2022-11-28 오후 8 40 59" src="https://user-images.githubusercontent.com/69030160/204271155-43804c10-8a6f-4838-a256-ec7503c3d562.png">

- 최근 자세 조회 `GET /api/v1/posture`
  - 조회시 자세 데이터가 없을 경우 올바른 자세인 자세 데이터를 하나 생성해서 반환합니다!
  <img width="1025" alt="스크린샷 2022-11-28 오후 8 41 11" src="https://user-images.githubusercontent.com/69030160/204271193-55cf4542-c66f-4663-a3d1-3c2c41119d8f.png">
