### PR TITLE
[TIME] 시간 목록 월별 조회 -> 시간 단일 일별 조회로 수정

### DIFF
--- a/src/main/java/com/buddy/study/common/dto/ErrorCode.java
+++ b/src/main/java/com/buddy/study/common/dto/ErrorCode.java
@@ -9,8 +9,10 @@ public enum ErrorCode {
     DUPLICATE_EMAIL("C001","이메일이 중복되었습니다."),
     MAXIMUM_GROUP("C002","현재 최대인원으로 가입할 수 없습니다."),
     DUPLICATE_GROUP("C003", "이미 가입한 그룹입니다."),
-    INVALIDATE_DATE("C004", "날짜 형식이 요구되는 형식과 맞지 않습니다."),
+    INVALIDATE_MONTH("C004", "날짜 형식이 요구되는 형식(yyyy-MM)과 맞지 않습니다."),
+    INVALIDATE_DATE("C004", "날짜 형식이 요구되는 형식(yyyy-MM-dd)과 맞지 않습니다."),
     INVALIDATE_TIME("C005", "목표시간 범위는 1 이상 24 이하 입니다."),
+    NOTFOUND_DATE("C006", "존재하지 않는 날짜입니다."),
 
     //Unauthorized : 401
     INVALID_EMAIL("U000","가입되지 않은 이메일입니다."),

--- a/src/main/java/com/buddy/study/time/controller/TimeController.java
+++ b/src/main/java/com/buddy/study/time/controller/TimeController.java
@@ -32,7 +32,6 @@ public class TimeController {
     @GetMapping("/date/{date}")
     public ResponseEntity<TimeResponse> getTimeByDate(@RequestHeader("Authorization") UUID userId, @PathVariable String date) {
         String formattedDate =  timeService.validateDate(date);
-        System.out.println(formattedDate);
         return ResponseEntity.ok(timeService.getTimeByDate(userId, formattedDate));
     }
 
@@ -40,7 +39,6 @@ public class TimeController {
     @GetMapping("/month/{month}/report")
     public ResponseEntity<TimeReportResponse> getReportByMonth(@RequestHeader("Authorization") UUID userId, @PathVariable String month) {
         String formattedMonth =  timeService.validateMonth(month);
-        System.out.println(formattedMonth);
         return ResponseEntity.ok(timeService.getTimeReportByMonth(userId, formattedMonth));
     }
 

--- a/src/main/java/com/buddy/study/time/controller/TimeController.java
+++ b/src/main/java/com/buddy/study/time/controller/TimeController.java
@@ -27,21 +27,24 @@ public class TimeController {
     public ResponseEntity<TimeResponse> createTime(@RequestHeader("Authorization") UUID userId, @RequestBody CreateRequest request) {
         return ResponseEntity.ok(timeService.createTime(userId, request));
     }
-    @Operation(summary = "월 공부 시간 출력")
-    @GetMapping("/month/{month}")
-    public ResponseEntity<List<TimeResponse>> getTimesByMonth(@RequestHeader("Authorization") UUID userId, @PathVariable String month) {
-        String formattedMonth =  timeService.validateDate(month);
-        System.out.println(formattedMonth);
-        return ResponseEntity.ok(timeService.getTimesByMonth(userId, formattedMonth));
+
+    @Operation(summary = "일 공부 시간 출력")
+    @GetMapping("/date/{date}")
+    public ResponseEntity<TimeResponse> getTimeByDate(@RequestHeader("Authorization") UUID userId, @PathVariable String date) {
+        String formattedDate =  timeService.validateDate(date);
+        System.out.println(formattedDate);
+        return ResponseEntity.ok(timeService.getTimeByDate(userId, formattedDate));
     }
+
     @Operation(summary = "월 시간 통계(평균,최소,최대)")
     @GetMapping("/month/{month}/report")
     public ResponseEntity<TimeReportResponse> getReportByMonth(@RequestHeader("Authorization") UUID userId, @PathVariable String month) {
-        String formattedMonth =  timeService.validateDate(month);
+        String formattedMonth =  timeService.validateMonth(month);
         System.out.println(formattedMonth);
         return ResponseEntity.ok(timeService.getTimeReportByMonth(userId, formattedMonth));
     }
-    @Operation(summary = "하루 공부 시간 출력")
+
+    @Operation(summary = "오늘 공부 시간 출력")
     @GetMapping("/today")
     public ResponseEntity<TimeResponse> getTodayTime(@RequestHeader("Authorization") UUID userId) {
         return ResponseEntity.ok(timeService.getTodayTime(userId));

--- a/src/main/java/com/buddy/study/time/repository/TimeRepository.java
+++ b/src/main/java/com/buddy/study/time/repository/TimeRepository.java
@@ -3,16 +3,12 @@ package com.buddy.study.time.repository;
 import com.buddy.study.account.domain.Account;
 import com.buddy.study.time.domain.Time;
 import com.buddy.study.time.dto.TimeReportResponse;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TimeRepository extends JpaRepository<Time, Long> {
-    @Query("select t from Time t where t.account = :account and t.date like :date% order by t.date")
-    List<Time> findAllByDateAndAccount(@Param("date") String date, @Param("account") Account account); // date YYYY-MM
-
     @Query("select new com.buddy.study.time.dto.TimeReportResponse(AVG(t.time), SUM(t.time), MAX(t.time), MIN(t.time)) from Time t where t.account = :account and t.date like :date%")
     TimeReportResponse findReportByDateAndAccount(@Param("date") String date, @Param("account") Account account);
 

--- a/src/main/java/com/buddy/study/time/service/TimeService.java
+++ b/src/main/java/com/buddy/study/time/service/TimeService.java
@@ -29,9 +29,20 @@ public class TimeService {
 
     private final AccountService accountService;
 
-    public String validateDate(String date) { // yyyy-MM 형식인지 검증
+    public String validateMonth(String date) { // yyyy-MM 형식인지 검증
         try {
             SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM");
+            simpleDateFormat.setLenient(false);
+            Date result = simpleDateFormat.parse(date);
+            return simpleDateFormat.format(result);
+        } catch(ParseException e) {
+            throw new ConflictException(ErrorCode.INVALIDATE_MONTH);
+        }
+    }
+
+    public String validateDate(String date) {
+        try {
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
             simpleDateFormat.setLenient(false);
             Date result = simpleDateFormat.parse(date);
             return simpleDateFormat.format(result);
@@ -39,6 +50,7 @@ public class TimeService {
             throw new ConflictException(ErrorCode.INVALIDATE_DATE);
         }
     }
+
     public TimeResponse createTime(UUID userId, CreateRequest request) {
         Account account = accountService.findUser(userId);
         String today = LocalDate.now().toString();
@@ -53,13 +65,11 @@ public class TimeService {
         return new TimeResponse(timeRepository.save(time));
     }
 
-    public List<TimeResponse> getTimesByMonth(UUID userId, String month) {
+    public TimeResponse getTimeByDate(UUID userId, String date) {
         Account account = accountService.findUser(userId);
 
-        return timeRepository.findAllByDateAndAccount(month,account)
-            .stream()
-            .map(TimeResponse::new)
-            .collect(Collectors.toList());
+        return new TimeResponse(timeRepository.findOneByDateAndAccount(date,account)
+            .orElseThrow(()->new ConflictException(ErrorCode.NOTFOUND_DATE)));
     }
 
     public TimeReportResponse getTimeReportByMonth(UUID userId, String month) {


### PR DESCRIPTION
API 요청 url 변경되었습니다! 이전 url 사용하지 않도록 주의해주세요!
- 일별 시간 조회 `GET /api/v1/time/date/{date}` ex) `/api/v1/time/date/2022-11-26` 
  (~~이전 요청 url `GET /api/v1/time/month/{month}`~~)
  요청하는 `{date}`가 `yyyy-MM-dd` 형식이 아닐 경우 예외가 발생합니다.
  <img width="1002" alt="스크린샷 2022-12-02 오후 5 17 11" src="https://user-images.githubusercontent.com/69030160/205247543-ee0e9fa7-1f27-46bd-9e4f-46bae1e443b7.png">

  요청하는 날짜에 측정된 공부 시간 데이터가 없을 경우 예외가 발생합니다.
  
  <img width="1017" alt="스크린샷 2022-12-02 오후 5 10 21" src="https://user-images.githubusercontent.com/69030160/205247416-115623db-e517-4461-9f5d-d63964882ada.png">

  요청하는 날짜에 측정된 공부 시간 데이터가 있을 경우 단일로 반환됩니다.
 
  <img width="1003" alt="스크린샷 2022-12-02 오후 5 11 54" src="https://user-images.githubusercontent.com/69030160/205247398-3e80148e-6fb2-432f-a152-2efd97c9fe20.png">
